### PR TITLE
fix: isASocialNetworkUrl() regex for summarize-cool-pages

### DIFF
--- a/src/__tests__/regex.spec.ts
+++ b/src/__tests__/regex.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { isASocialNetworkUrl } from '../helpers/regex.helper';
+
+describe('Helpers: Regex', () => {
+  describe('Rule: isASocialNetworkUrl should regex correctly an url', () => {
+    it('isASocialNetworkUrl() should return true when the url is a social network url', () => {
+      const url = 'www.facebook.com/username';
+      const result = isASocialNetworkUrl(url);
+      expect(result).toBe(true);
+    });
+    it('isASocialNetworkUrl() should return false when the url is not a social network url', () => {
+      const url = 'https://blog.richardekwonye.com/bezier-curves';
+      const result = isASocialNetworkUrl(url);
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/__tests__/summarize-cool-pages.spec.ts
+++ b/src/__tests__/summarize-cool-pages.spec.ts
@@ -3,9 +3,11 @@ import { afterEach } from 'node:test';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
-  getPageSummaryDiscordView,
   NoContentFoundSummaryError,
+  getPageSummaryDiscordView,
+  isPageSummarizeSuccessData,
   parseHtmlSummarized,
+  type PageSummarizerData,
 } from '../summarize-cool-pages';
 
 const createSummarizeCoolPagesFixture = () => {
@@ -70,5 +72,24 @@ describe('Feature: summarize cool pages', () => {
   });
   it('getPageSummaryDiscordView() should return a string with the page summary', () => {
     expect(getPageSummaryDiscordView(fixture.pageSummary)).toEqual(fixture.pageSummaryDiscordView);
+  });
+
+  describe('Rule: isPageSummarizeSuccessData() should check if the data is a PageSummarizerDataSuccess', () => {
+    it('isPageSummarizeSuccessData() should return true when the data is a PageSummarizerDataSuccess', () => {
+      const data = {
+        success: true,
+        html: fixture.htmlWithSummaryContent,
+      } as PageSummarizerData;
+      const result = isPageSummarizeSuccessData(data);
+      expect(result).toBe(true);
+    });
+    it('isPageSummarizeSuccessData() should return false when the data is not a PageSummarizerDataSuccess', () => {
+      const data = {
+        success: false,
+        html: undefined,
+      } as PageSummarizerData;
+      const result = isPageSummarizeSuccessData(data);
+      expect(result).toBe(false);
+    });
   });
 });

--- a/src/__tests__/summarize-cool-pages.spec.ts
+++ b/src/__tests__/summarize-cool-pages.spec.ts
@@ -1,15 +1,11 @@
-import { afterEach } from 'node:test';
-
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
-  NoContentFoundSummaryError,
   getPageSummaryDiscordView,
   isPageSummarizeSuccessData,
+  NoContentFoundSummaryError,
   parseHtmlSummarized,
-  type PageSummarizerData,
 } from '../summarize-cool-pages';
-
 const createSummarizeCoolPagesFixture = () => {
   return {
     // from https://react.dev/learn/you-might-not-need-an-effect
@@ -76,10 +72,14 @@ describe('Feature: summarize cool pages', () => {
 
   describe('Rule: isPageSummarizeSuccessData() should check if the data is a PageSummarizerDataSuccess', () => {
     it('isPageSummarizeSuccessData() should return true when the data is a PageSummarizerDataSuccess', () => {
+      // I'm using as because eslint can't autofix and sort the import itself
       const data = {
         success: true,
         html: fixture.htmlWithSummaryContent,
-      } as PageSummarizerData;
+      } as {
+        success: true;
+        html: string;
+      };
       const result = isPageSummarizeSuccessData(data);
       expect(result).toBe(true);
     });
@@ -87,7 +87,10 @@ describe('Feature: summarize cool pages', () => {
       const data = {
         success: false,
         html: undefined,
-      } as PageSummarizerData;
+      } as {
+        success: false;
+        html: undefined;
+      };
       const result = isPageSummarizeSuccessData(data);
       expect(result).toBe(false);
     });

--- a/src/cool-links-management.ts
+++ b/src/cool-links-management.ts
@@ -1,6 +1,7 @@
 import { ThreadAutoArchiveDuration, type Message } from 'discord.js';
 import ogs from 'open-graph-scraper';
 
+import { isASocialNetworkUrl } from './helpers/regex.helper';
 import { getPageSummary } from './summarize-cool-pages';
 import { getVideoSummary } from './summarize-cool-videos';
 
@@ -28,9 +29,6 @@ const getThreadNameFromOpenGraph = async (url: string): Promise<string | null> =
 };
 
 const youtubeUrlRegex = new RegExp('^(https?)?(://)?(www.)?(m.)?((youtube.com)|(youtu.be))');
-const socialNetworksUrlRegex = new RegExp(
-  '^(?!.*(fb.me|facebook.com|t.co|instagr.am|instagram.com|lnkd.in|youtu.be|tiktok.com)).*$',
-);
 
 export const coolLinksManagement = async (message: Message) => {
   const urlRegex = /(((https?:\/\/)|(www\.))[^\s]+)/g;
@@ -58,7 +56,7 @@ export const coolLinksManagement = async (message: Message) => {
 
     await thread.send(summary);
   }
-  if (!youtubeUrlRegex.test(url) && !socialNetworksUrlRegex.test(url)) {
+  if (!youtubeUrlRegex.test(url) && !isASocialNetworkUrl(url)) {
     try {
       const pageSummaryDiscordView = await getPageSummary(url);
       await thread.send(pageSummaryDiscordView);

--- a/src/helpers/regex.helper.ts
+++ b/src/helpers/regex.helper.ts
@@ -1,0 +1,6 @@
+const socialNetworksUrlRegex = new RegExp(
+  '^(https?://)?(www.)?(facebook.com|fb.me|twitter.com|instagram.com|linkedin.com|youtube.com|youtu.be|pinterest.com|snapchat.com|tiktok.com)/[a-zA-Z0-9.-/?=&#_]+$',
+);
+export const isASocialNetworkUrl = (url: string): boolean => {
+  return socialNetworksUrlRegex.test(url);
+};

--- a/src/helpers/regex.helper.ts
+++ b/src/helpers/regex.helper.ts
@@ -1,5 +1,5 @@
 const socialNetworksUrlRegex = new RegExp(
-  '^(https?://)?(www.)?(facebook.com|fb.me|twitter.com|instagram.com|linkedin.com|youtube.com|youtu.be|pinterest.com|snapchat.com|tiktok.com)/[a-zA-Z0-9.-/?=&#_]+$',
+  '^(https?://)?(www.)?(facebook.com|fb.me|twitter.com|vxtwitter.com|instagram.com|linkedin.com|youtube.com|youtu.be|pinterest.com|snapchat.com|tiktok.com)/[a-zA-Z0-9.-/?=&#_]+$',
 );
 export const isASocialNetworkUrl = (url: string): boolean => {
   return socialNetworksUrlRegex.test(url);

--- a/src/summarize-cool-pages.ts
+++ b/src/summarize-cool-pages.ts
@@ -11,19 +11,19 @@ type PageSummary = {
   readingTime: string;
 };
 
-type PageSummarizerDataSuccess = {
+export type PageSummarizerDataSuccess = {
   success: true;
   html: string;
 };
 
-type PageSummarizerDataFailure = {
+export type PageSummarizerDataFailure = {
   success: false;
   html?: undefined;
 };
 
-type PageSummarizerData = PageSummarizerDataSuccess | PageSummarizerDataFailure;
+export type PageSummarizerData = PageSummarizerDataSuccess | PageSummarizerDataFailure;
 
-const isPageSummarizeSuccessData = (
+export const isPageSummarizeSuccessData = (
   data: PageSummarizerData,
 ): data is PageSummarizerDataSuccess => {
   return data?.success && typeof data?.html === 'string';


### PR DESCRIPTION
- Refactor the old regex that does not fire to check if it's a social network URL
- Add test for isASocialNetworkUrl(), and for isPageSummarizeSuccessData() guard (maybe to much)