### PR TITLE
feat: allow modules to export intents

### DIFF
--- a/src/core/getIntentsFromModules.ts
+++ b/src/core/getIntentsFromModules.ts
@@ -1,0 +1,6 @@
+import type { BotModule } from '../types/bot';
+
+export const getIntentsFromModules = (modules: Record<string, BotModule>) => {
+  const intents = Object.values(modules).flatMap((module) => module.intents ?? []);
+  return [...new Set(intents)] as const;
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,14 @@
 import { Client } from 'discord.js';
 
 import { config } from './config';
+import { getIntentsFromModules } from './core/getIntentsFromModules';
 import { loadModules } from './core/loadModules';
 import { modules } from './modules/modules';
 
 const { discord } = config;
+
 const client = new Client({
-  intents: ['Guilds', 'GuildVoiceStates', 'GuildMembers', 'GuildMessages', 'MessageContent'],
+  intents: getIntentsFromModules(modules),
 });
 
 await client.login(discord.token);

--- a/src/modules/coolLinksManagement/coolLinksManagement.module.ts
+++ b/src/modules/coolLinksManagement/coolLinksManagement.module.ts
@@ -77,4 +77,5 @@ export const coolLinksManagement: BotModule = {
       }
     },
   },
+  intents: ['GuildMessages', 'MessageContent', 'GuildMessageReactions'],
 };

--- a/src/modules/patternReplace/patternReplace.module.ts
+++ b/src/modules/patternReplace/patternReplace.module.ts
@@ -38,4 +38,5 @@ export const patternReplace: BotModule = {
       await message.delete();
     },
   },
+  intents: ['GuildMessages', 'MessageContent'],
 };

--- a/src/modules/quoiFeur/quoiFeur.module.ts
+++ b/src/modules/quoiFeur/quoiFeur.module.ts
@@ -32,4 +32,5 @@ export const quoiFeur: BotModule = {
     ready: deleteRoleMutedOnCoubeh,
     messageCreate: reactOnEndWithQuoi,
   },
+  intents: ['Guilds', 'GuildMessages', 'MessageContent', 'GuildMessageReactions'],
 };

--- a/src/modules/voiceOnDemand/voiceOnDemand.module.ts
+++ b/src/modules/voiceOnDemand/voiceOnDemand.module.ts
@@ -93,4 +93,5 @@ export const voiceOnDemand: BotModule = {
       }
     },
   },
+  intents: ['GuildVoiceStates', 'GuildMembers'],
 };

--- a/src/types/bot.ts
+++ b/src/types/bot.ts
@@ -1,6 +1,7 @@
 import type {
   ChatInputCommandInteraction,
   ClientEvents,
+  ClientOptions,
   RESTPostAPIChatInputApplicationCommandsJSONBody,
 } from 'discord.js';
 
@@ -22,4 +23,5 @@ export type BotModule = {
   eventHandlers?: {
     [key in keyof ClientEvents]?: EventHandler<key>;
   };
+  intents?: ClientOptions['intents'];
 };


### PR DESCRIPTION
# Problem
Modules aren't as self-contains as it gets, if a certain modules need an intent that we didn't initially planned, he shouldn't have to edit main.ts .

# Solution
Allow modules to export their intents, and load it at bot start.