### PR TITLE
fix: change removeEmoji regex to include custom emojis

### DIFF
--- a/src/__tests__/regex.spec.ts
+++ b/src/__tests__/regex.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isASocialNetworkUrl } from '../helpers/regex.helper';
+import { isASocialNetworkUrl, removeEmoji } from '../helpers/regex.helper';
 
 describe('Helpers: Regex', () => {
   describe('Rule: isASocialNetworkUrl should regex correctly an url', () => {
@@ -13,6 +13,13 @@ describe('Helpers: Regex', () => {
       const url = 'https://blog.richardekwonye.com/bezier-curves';
       const result = isASocialNetworkUrl(url);
       expect(result).toBe(false);
+    });
+  });
+  describe('Rule: removeEmoji should remove all emojis from a string', () => {
+    it('removeEmoji() should remove all emojis from a string', () => {
+      const text = '👋 Hello, World!<:SpongebobMock:1136008737669259407>';
+      const result = removeEmoji(text);
+      expect(result).toBe(' Hello, World!');
     });
   });
 });

--- a/src/helpers/regex.helper.ts
+++ b/src/helpers/regex.helper.ts
@@ -2,7 +2,7 @@ const socialNetworksUrlRegex = new RegExp(
   '^(https?://)?(www.)?(facebook.com|fb.me|twitter.com|vxtwitter.com|instagram.com|linkedin.com|youtube.com|youtu.be|pinterest.com|snapchat.com|tiktok.com)/[a-zA-Z0-9.-/?=&#_]+$',
 );
 const punctuationRegex = /[.,!?]/g;
-const emojiRegex = /<a?:.+?:\d{18}>|\p{Extended_Pictographic}/gu;
+const emojiRegex = /<a?:.+?:\d{10,30}>|\p{Extended_Pictographic}/gu;
 
 export const isASocialNetworkUrl = (url: string): boolean => {
   return socialNetworksUrlRegex.test(url);

--- a/src/helpers/regex.helper.ts
+++ b/src/helpers/regex.helper.ts
@@ -2,7 +2,7 @@ const socialNetworksUrlRegex = new RegExp(
   '^(https?://)?(www.)?(facebook.com|fb.me|twitter.com|vxtwitter.com|instagram.com|linkedin.com|youtube.com|youtu.be|pinterest.com|snapchat.com|tiktok.com)/[a-zA-Z0-9.-/?=&#_]+$',
 );
 const punctuationRegex = /[.,!?]/g;
-const emojiRegex = /(\p{Extended_Pictographic}|\p{Emoji_Component})/gu;
+const emojiRegex = /<a?:.+?:\d{18}>|\p{Extended_Pictographic}/gu;
 
 export const isASocialNetworkUrl = (url: string): boolean => {
   return socialNetworksUrlRegex.test(url);


### PR DESCRIPTION
(Just tried something after a bit of documentation)
I replaced the original regular expression to delete the emojis (`/(\p{Extended_Pictographic}|\p{Emoji_Component})/gu`), since it doesn't catches the custom emojis which are formatted as such `<:emoji_name:emoji_id>`

As shown in some requests, the custom emojis are really formatted as such:
![image](https://github.com/codinglab-io/discord-bot/assets/42476297/5345c4e4-acfb-42c7-a531-f9f29aff180b)

