### PR TITLE
fix: use the quoifeurbot in public thread of allowed channels

### DIFF
--- a/src/modules/quoiFeur/quoiFeur.helpers.ts
+++ b/src/modules/quoiFeur/quoiFeur.helpers.ts
@@ -30,10 +30,7 @@ export const reactOnEndWithQuoi = async (message: Message) => {
 
   const channelIds = await cache.get('quoiFeurChannels', []);
 
-  let messageParentId = null;
-  if (message.channel.type === ChannelType.PublicThread) {
-    messageParentId = message.channel.parentId;
-  }
+  const messageParentId = message.channel.type === ChannelType.PublicThread ? message.channel.parentId : null
 
   const isMessageInQuoiFeurChannel = (
     channelIds.includes(message.channelId) || 

--- a/src/modules/quoiFeur/quoiFeur.helpers.ts
+++ b/src/modules/quoiFeur/quoiFeur.helpers.ts
@@ -29,8 +29,18 @@ export const reactOnEndWithQuoi = async (message: Message) => {
   if (!endWithQuoi(message.content)) return;
 
   const channelIds = await cache.get('quoiFeurChannels', []);
-  const channelHasGame = channelIds.find((channelId) => channelId === message.channelId);
-  if (!channelHasGame) return;
+
+  let messageParentId = null;
+  if (message.channel.type === ChannelType.PublicThread) {
+    messageParentId = message.channel.parentId;
+  }
+
+  const isMessageInQuoiFeurChannel = (
+    channelIds.includes(message.channelId) || 
+    (messageParentId && channelIds.includes(messageParentId))
+  );
+  
+  if (!isMessageInQuoiFeurChannel) return;
 
   const probability = 1 / 6;
 

--- a/src/modules/quoiFeur/quoiFeur.helpers.ts
+++ b/src/modules/quoiFeur/quoiFeur.helpers.ts
@@ -30,13 +30,13 @@ export const reactOnEndWithQuoi = async (message: Message) => {
 
   const channelIds = await cache.get('quoiFeurChannels', []);
 
-  const messageParentId = message.channel.type === ChannelType.PublicThread ? message.channel.parentId : null
+  const messageParentId =
+    message.channel.type === ChannelType.PublicThread ? message.channel.parentId : null;
 
-  const isMessageInQuoiFeurChannel = (
-    channelIds.includes(message.channelId) || 
-    (messageParentId && channelIds.includes(messageParentId))
-  );
-  
+  const isMessageInQuoiFeurChannel =
+    channelIds.includes(message.channelId) ||
+    (messageParentId && channelIds.includes(messageParentId));
+
   if (!isMessageInQuoiFeurChannel) return;
 
   const probability = 1 / 6;


### PR DESCRIPTION
As the title says, when I say "quoi" in a thread created in an allowed channel, the bot doesn't react.
This is due to the fact that the message's channel parentId is not being verified.

(link of that property in the documentation: https://old.discordjs.dev/#/docs/discord.js/14.13.0/class/ThreadChannel?scrollTo=parentId)