### PR TITLE
fix: wrong names of the handlers of quoifeur module

### DIFF
--- a/src/modules/quoiFeur/quoiFeur.module.ts
+++ b/src/modules/quoiFeur/quoiFeur.module.ts
@@ -22,8 +22,8 @@ export const quoiFeur: BotModule = {
         )
         .toJSON(),
       handler: {
-        add: addQuoiFeurToChannel,
-        remove: removeQuoiFeurFromChannel,
+        enable: addQuoiFeurToChannel,
+        disable: removeQuoiFeurFromChannel,
       },
     },
   ],


### PR DESCRIPTION
Handler names do not reflect Discord subcommand names of the quoifeur module