### PR TITLE
fix: utf8 char breaks quoifeur

### DIFF
--- a/src/helpers/regex.helper.ts
+++ b/src/helpers/regex.helper.ts
@@ -4,6 +4,7 @@ const socialNetworksUrlRegex = new RegExp(
 const punctuationRegex = /[.,!?]/g;
 const markdownRegex = /(\*\*|__|\*|_|`|~)(.*?)\1/g;
 const emojiRegex = /<a?:.+?:\d{10,30}>|\p{Extended_Pictographic}/gu;
+const nonASCIIRegex = /[\u{007F}-\u{FFFF}]/gu; 
 
 export const isASocialNetworkUrl = (url: string): boolean => {
   return socialNetworksUrlRegex.test(url);
@@ -11,4 +12,5 @@ export const isASocialNetworkUrl = (url: string): boolean => {
 
 export const removePunctuation = (text: string) => text.replaceAll(punctuationRegex, '');
 export const removeEmoji = (text: string) => text.replaceAll(emojiRegex, '');
+export const removeNonASCII = (text: string) => text.replaceAll(nonASCIIRegex, '');
 export const removeMarkdown = (text: string) => text.replaceAll(markdownRegex, '$2');

--- a/src/helpers/regex.helper.ts
+++ b/src/helpers/regex.helper.ts
@@ -4,7 +4,7 @@ const socialNetworksUrlRegex = new RegExp(
 const punctuationRegex = /[.,!?]/g;
 const markdownRegex = /(\*\*|__|\*|_|`|~)(.*?)\1/g;
 const emojiRegex = /<a?:.+?:\d{10,30}>|\p{Extended_Pictographic}/gu;
-const nonASCIIRegex = /[\u{007F}-\u{FFFF}]/gu; 
+const nonASCIIRegex = /[\u{007F}-\u{FFFF}]/gu;
 
 export const isASocialNetworkUrl = (url: string): boolean => {
   return socialNetworksUrlRegex.test(url);

--- a/src/modules/quoiFeur/quoiFeur.helpers.ts
+++ b/src/modules/quoiFeur/quoiFeur.helpers.ts
@@ -7,13 +7,18 @@ import {
 } from 'discord.js';
 
 import { cache } from '../../core/cache';
-import { removeEmoji, removeMarkdown, removePunctuation } from '../../helpers/regex.helper';
+import {
+  removeEmoji,
+  removeMarkdown,
+  removePunctuation,
+  removeNonASCII
+} from '../../helpers/regex.helper';
 
 const ONE_MINUTE = 1 * 60 * 1000;
 
 const quoiDetectorRegex = /\bquoi\s*$/i;
 const endWithQuoi = (text: string) =>
-  quoiDetectorRegex.test(removeEmoji(removePunctuation(removeMarkdown(text))));
+  quoiDetectorRegex.test(removeNonASCII(removeEmoji(removePunctuation(removeMarkdown(text)))));
 
 const reactWith = async (message: Message, reactions: string[]) => {
   for (const reaction of reactions) {

--- a/src/modules/quoiFeur/quoiFeur.helpers.ts
+++ b/src/modules/quoiFeur/quoiFeur.helpers.ts
@@ -10,8 +10,8 @@ import { cache } from '../../core/cache';
 import {
   removeEmoji,
   removeMarkdown,
+  removeNonASCII,
   removePunctuation,
-  removeNonASCII
 } from '../../helpers/regex.helper';
 
 const ONE_MINUTE = 1 * 60 * 1000;


### PR DESCRIPTION
Unwanted behavior : invisible UTF8 chars breaks command from running as expected

Fix : sanitize input by removing non ascii chars.

Content : added regex helper for non ascii chars. The drawback is that it replaces accents from content that is maybe not ideal for french content (but totally matching the code as it is described - non ascii are out). In our scenario, it should not break `quoifeur` behavior though.