### PR TITLE
fix(voiceOnDemand): remove duplicate channel deletion related code

### DIFF
--- a/src/modules/voiceOnDemand/voiceOnDemand.module.ts
+++ b/src/modules/voiceOnDemand/voiceOnDemand.module.ts
@@ -84,28 +84,15 @@ export const voiceOnDemand = createModule({
       }
 
       const lobbyIds = await cache.get('lobbyIds', []);
-      const onDemandChannels = await cache.get('onDemandChannels', []);
-
       const isLobbyChannel = lobbyIds.includes(channel.id);
-      const isOnDemandChannel = onDemandChannels.includes(channel.id);
 
-      if (!isOnDemandChannel && !isLobbyChannel) {
+      if (!isLobbyChannel) {
         return;
       }
 
       await cache.set(
         'lobbyIds',
         lobbyIds.filter((lobbyId) => lobbyId !== channel.id),
-      );
-
-      await Promise.all(
-        onDemandChannels.map(async (id) => {
-          const updatedChannel = await channel.guild.channels.fetch(id).catch(() => null);
-          if (updatedChannel !== null) {
-            await channel.guild.channels.delete(id);
-            channel.guild.channels.cache.delete(id);
-          }
-        }),
       );
     },
   }),


### PR DESCRIPTION
This fixes the following bug: 
 1. A user disconnects from a voice channel
 2. The channel proceeds to get deleted because there isn't anyone in the channel anymore
 3. (bug) All the voice channels gets deleted (except the lobby one)

From my understanding, channel deletion is already handled [here](https://github.com/codinglab-io/discord-bot/blob/master/src/modules/voiceOnDemand/voiceOnDemand.helpers.ts#L26)

and the role of this [handler](https://github.com/codinglab-io/discord-bot/blob/master/src/modules/voiceOnDemand/voiceOnDemand.module.ts#L81) should only to remove channel from cache if its a lobby one right ?

To me this bug is even worse because it seems that even across multiple servers, someone leaving a voice channel in a guild, would provoke the deletion of every voice channels in every guild.

Anyway, tested on a local discord server, the bug is fixed, and the channel deletion still works when no user is left.
