### PR TITLE
feat(quoi-feur): cumulative streak punishment and prevent mute evading

### DIFF
--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -23,6 +23,7 @@ interface Cache<Entries extends Record<string, any>> {
 interface CacheEntries {
   lobbyIds: string[];
   onDemandChannels: string[];
+  quoiAccumulation: number;
   quoiFeurChannels: string[];
   recurringMessages: { id: string; channelId: string; frequency: Frequency; message: string }[];
 }

--- a/src/modules/quoiFeur/quoiFeur.helpers.ts
+++ b/src/modules/quoiFeur/quoiFeur.helpers.ts
@@ -38,6 +38,7 @@ export const reactOnEndWithQuoi = async (message: Message) => {
   if (!endWithQuoi(message.content)) return;
 
   const channelIds = await cache.get('quoiFeurChannels', []);
+  const accumulation = await cache.get('quoiAccumulation', 1);
 
   const messageParentId =
     message.channel.type === ChannelType.PublicThread ? message.channel.parentId : null;
@@ -51,14 +52,17 @@ export const reactOnEndWithQuoi = async (message: Message) => {
   const probability = 1 / 6;
 
   if (Math.random() <= probability) {
-    await reactWithCoubeh(message);
     await message.member?.timeout(
-      ONE_MINUTE * 5,
+      ONE_MINUTE * accumulation,
       `${message.member.displayName} have the cramptés`,
     );
+    await cache.set('quoiAccumulation', 1);
+    await reactWithCoubeh(message);
+    
     return;
   }
 
+  await cache.set('quoiAccumulation', accumulation + 1);
   await reactWithFeur(message);
 };
 


### PR DESCRIPTION
To improve fun:tm: and punish players in the most efficient way, the mute is now an accumulation of how many times "quoi" has been said since the last timeout.
e.g.: An "akhy" spam "quoi" 10 times and didn't get a timeout, then another random try to say "quoi" and got chosen by the "pseudo-randomness": he will be muted for 11 minutes

The second feature is to prevent cheat by muting before displaying "coubeh". Some users just delete their messages before they get muted by the bot.